### PR TITLE
Post palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ Sample Response:
       projects_id: 91,
       created_at: '2020-02-05T01:49:59.421Z',
       updated_at: '2020-02-05T01:49:59.421Z' }`
+
+### POST `/api/v1/projects/:id/palettes`
+Sample Response:
+`{ id: 553 }`

--- a/app.js
+++ b/app.js
@@ -4,10 +4,10 @@ const app = express();
 
 app.use(express.json());
 app.use(cors());
-// app.use(express.static('public'));   ???
+app.use(express.static('public'));
 
 app.locals.title = 'Projects';
-// app.locals.id = 0;   ???
+app.locals.id = 0;
 
 const environment = process.env.NODE_ENV || 'development'
 const configuration = require('./knexfile')[environment]

--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ app.post('/api/v1/projects/:id/palettes', async (request, response) => {
     if (!palette.hasOwnProperty(requiredParameter)) {
       return response
         .status(422)
-        .send({ error: `The expected format is: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String> }. You are missing a "${requiredParameter}" property.` })
+        .send({ error: `Expected body format is: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String> }. You\'re missing the required "${requiredParameter}" property.` })
     }
   }
   try {

--- a/app.js
+++ b/app.js
@@ -29,11 +29,32 @@ app.get('/api/v1/palettes/:id', async (request, response) => {
     if (palettes.length) {
       response.status(200).json(palettes[0])
     } else {
-      response.status(404).json({error: `Could not find palette with an id of ${id}`})
+      response.status(404).json(
+        {error: `Could not find palette with an id of ${id}`})
     }
   } catch (error) {
     response.status(500).json({ error })
   }
-})
+});
+
+app.post('/api/v1/projects/:id/palettes', async (request, response) => {
+  const projects_id = request.params.id;
+  const palette = { ...request.body, projects_id: Number(projects_id) };
+
+  for (let requiredParameter of ['name', 'color_one', 'color_two',
+    'color_three', 'color_four', 'color_five', 'projects_id']) {
+    if (!palette.hasOwnProperty(requiredParameter)) {
+      return response
+        .status(422)
+        .send({ error: `The expected format is: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String> }. You are missing a "${requiredParameter}" property.` })
+    }
+  }
+  try {
+    const id = await database('palettes').insert(palette, 'id');
+    response.status(201).json({ id: id[0] });
+  } catch (error) {
+    response.status(500).json({ error });
+  }
+});
 
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -57,4 +57,21 @@ app.post('/api/v1/projects/:id/palettes', async (request, response) => {
   }
 });
 
+app.delete('/api/v1/palettes/:id', async (request, response) => {
+  const palettes_id = request.params.id;
+  try {
+    const found = await database('palettes').where('id', palettes_id);
+    if (found.length) {
+      const id = await database('palettes').where('id', palettes_id).del();
+      response.status(200).send(`Palette with id ${palettes_id} has been removed successfully`);
+    } else {
+      response.status(404).json({
+        error: `Could not find palette with an id of ${palettes_id}`
+      })
+    }
+  } catch (error) {
+    response.status(500).json({ error });
+  }
+});
+
 module.exports = app;

--- a/app.test.js
+++ b/app.test.js
@@ -59,7 +59,24 @@ describe('Server', () => {
         const palette = palettes[0];
         expect(response.status).toBe(201);
         expect(palette.name).toEqual(newPalette.name);
-    })
-  })
+    });
 
-})
+    it('should return a 422 if properties are missing from request body',
+      async () => {
+        const expectedProject = await database('projects').first();
+        const { id } = expectedProject;
+        const newPalette = {
+          color_one: '#111111',
+          color_two: '#222222',
+          color_three: '#333333',
+          color_four: '#444444',
+          color_five: '#555555',
+          projects_id: id
+        };
+        const response = await request(app).post
+          (`/api/v1/projects/${id}/palettes`).send(newPalette);
+        expect(response.status).toBe(422);
+        expect(response.body.error).toEqual('The expected format is: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String> }. You are missing a "name" property.')
+    });
+  });
+});

--- a/app.test.js
+++ b/app.test.js
@@ -36,6 +36,30 @@ describe('Server', () => {
       const response = await request(app).get(`/api/v1/palettes/${invalidId}`);
       expect(response.status).toBe(404);
       expect(response.body.error).toEqual(`Could not find palette with an id of ${invalidId}`);
+    });
+  });
+
+  describe('POST /api/v1/projects/:id/palettes', () => {
+    it('should return a 201 with the id of the newly created palette',
+      async () => {
+        const expectedProject = await database('projects').first();
+        const { id } = expectedProject;
+        const newPalette = {
+          name: 'new palette',
+          color_one: '#111111',
+          color_two: '#222222',
+          color_three: '#333333',
+          color_four: '#444444',
+          color_five: '#555555',
+          projects_id: id
+        };
+        const response = await request(app).post
+          (`/api/v1/projects/${id}/palettes`).send(newPalette);
+        const palettes = await database('palettes').where('id', response.body.id);
+        const palette = palettes[0];
+        expect(response.status).toBe(201);
+        expect(palette.name).toEqual(newPalette.name);
     })
   })
+
 })

--- a/app.test.js
+++ b/app.test.js
@@ -76,7 +76,7 @@ describe('Server', () => {
         const response = await request(app).post
           (`/api/v1/projects/${id}/palettes`).send(newPalette);
         expect(response.status).toBe(422);
-        expect(response.body.error).toEqual('The expected format is: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String> }. You are missing a "name" property.')
+        expect(response.body.error).toEqual('Expected body format is: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String> }. You\'re missing the required "name" property.')
     });
   });
 

--- a/app.test.js
+++ b/app.test.js
@@ -79,4 +79,22 @@ describe('Server', () => {
         expect(response.body.error).toEqual('The expected format is: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String> }. You are missing a "name" property.')
     });
   });
+
+  describe('DELETE /api/v1/palettes/:id', () => {
+    it('should return a 200 with a success message if delete is successful', async () => {
+      const expectedPalette = await database('palettes').first();
+      const { id } = expectedPalette;
+      const response = await request(app).delete(`/api/v1/palettes/${id}`).send(`${id}`);
+      const doesExist = await database('palettes').where('id', id);
+      expect(response.status).toBe(200);
+      expect(doesExist.length).toEqual(0);
+    });
+
+    it('should return a 404 with a not found error message if item to delete does not exist', async () => {
+      const invalidId = -4;
+      const response = await request(app).delete(`/api/v1/palettes/${invalidId}`).send(`${invalidId}`);
+      expect(response.status).toBe(404);
+      expect(response.body.error).toEqual(`Could not find palette with an id of ${invalidId}`)
+    });
+  });
 });


### PR DESCRIPTION
### What's this PR do?
- `/api/v1/projects/:id/palettes`
  - Adds tests (happy and sad) for POST palette to `/api/v1/projects/:id/palettes`
  - Add endpoint `/api/v1/projects/:id/palettes`
  - Add sample response to README

- `/api/v1/palettes/:id`
  - Adds tests (happy and sad) for DELETE palette from `/api/v1/palettes/:id`
  - Add endpoint `/api/v1/palettes/:id`

### How should this be manually tested?
- run `npm test`

### What are the relevant tickets?
Issue #31, 32, 33, 34