### PR TITLE
Delete (1) and patch (2)

### DIFF
--- a/app.js
+++ b/app.js
@@ -109,8 +109,13 @@ app.patch('/api/v1/projects/:id', async (request, response) => {
   const updatedInfo = request.body;
   const projects_id = request.params.id;
   const foundProject = await database('projects').where('id', projects_id);
+  let requestKeys = Object.keys(updatedInfo);
 
-  // if (!foundProject) <set up 422 to ensure key sent in request.body exists in project
+  if (requestKeys.length !== 1 || requestKeys[0] !== 'name') {
+    return response
+      .status(422)
+      .send({ error: `Expected body format is: { name: <String> }. You must send only the required "name" property.` })
+  }
 
   try {
     if (foundProject.length) {

--- a/app.js
+++ b/app.js
@@ -134,7 +134,7 @@ app.patch('/api/v1/projects/:id', async (request, response) => {
 
 app.patch('/api/v1/palettes/:id', async (request, response) => {
   const updatedInfo = request.body;
-  const palettes_id = request.param.id;
+  const palettes_id = request.params.id;
   const foundPalette = await database('palettes').where('id', palettes_id);
   let requestKeys = Object.keys(updatedInfo);
 
@@ -143,7 +143,6 @@ app.patch('/api/v1/palettes/:id', async (request, response) => {
       .status(422)
       .send({ error: `Expected body format is: { name: <String> }. You must send only the required "name" property.` })
   }
-
   try {
     if (foundPalette.length) {
       const id = await database('palettes').where('id', palettes_id).update(updatedInfo, 'id');

--- a/app.js
+++ b/app.js
@@ -87,4 +87,23 @@ app.delete('/api/v1/palettes/:id', async (request, response) => {
   }
 });
 
+app.delete('/api/v1/projects/:id', async (request, response) => {
+  const projects_id = request.params.id;
+  try {
+    const found = await database('projects').where('id', projects_id);
+    if (found.length) {
+      const p_id = await database('palettes').where('projects_id', projects_id).del();
+
+      const id = await database('projects').where('id', projects_id).del();
+      response.status(200).send(`Project with id ${projects_id} has been removed successfully`);
+    } else {
+      response.status(404).json({
+        error: `Could not find project with an id of ${projects_id}`
+      })
+    }
+  } catch (error) {
+    response.status(500).json({ error });
+  }
+});
+
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -130,6 +130,32 @@ app.patch('/api/v1/projects/:id', async (request, response) => {
   } catch (error) {
     response.status(500).json({ error });
   }
-})
+});
+
+app.patch('/api/v1/palettes/:id', async (request, response) => {
+  const updatedInfo = request.body;
+  const palettes_id = request.param.id;
+  const foundPalette = await database('palettes').where('id', palettes_id);
+  let requestKeys = Object.keys(updatedInfo);
+
+  if (requestKeys.length !== 1 || requestKeys[0] !== 'name') {
+    return response
+      .status(422)
+      .send({ error: `Expected body format is: { name: <String> }. You must send only the required "name" property.` })
+  }
+
+  try {
+    if (foundPalette.length) {
+      const id = await database('palettes').where('id', palettes_id).update(updatedInfo, 'id');
+      response.status(200).json({ id: id[0] });
+    } else {
+      response.status(404).json({
+        error: `Could not find palette with an id of ${palettes_id}`
+      })
+    }
+  } catch (error) {
+    response.status(500).json({ error });
+  }
+});
 
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -75,7 +75,7 @@ app.delete('/api/v1/palettes/:id', async (request, response) => {
   try {
     const found = await database('palettes').where('id', palettes_id);
     if (found.length) {
-      const id = await database('palettes').where('id', palettes_id).del();
+      await database('palettes').where('id', palettes_id).del();
       response.status(200).send(`Palette with id ${palettes_id} has been removed successfully`);
     } else {
       response.status(404).json({
@@ -90,11 +90,10 @@ app.delete('/api/v1/palettes/:id', async (request, response) => {
 app.delete('/api/v1/projects/:id', async (request, response) => {
   const projects_id = request.params.id;
   try {
-    const found = await database('projects').where('id', projects_id);
-    if (found.length) {
-      const p_id = await database('palettes').where('projects_id', projects_id).del();
-
-      const id = await database('projects').where('id', projects_id).del();
+    const foundProject = await database('projects').where('id', projects_id);
+    if (foundProject.length) {
+      await database('palettes').where('projects_id', projects_id).del();
+      await database('projects').where('id', projects_id).del();
       response.status(200).send(`Project with id ${projects_id} has been removed successfully`);
     } else {
       response.status(404).json({
@@ -105,5 +104,27 @@ app.delete('/api/v1/projects/:id', async (request, response) => {
     response.status(500).json({ error });
   }
 });
+
+app.patch('/api/v1/projects/:id', async (request, response) => {
+  const updatedInfo = request.body;
+  const projects_id = request.params.id;
+  const foundProject = await database('projects').where('id', projects_id);
+
+  // if (!foundProject) <set up 422 to ensure key sent in request.body exists in project
+
+  try {
+    if (foundProject.length) {
+      const id = await database('projects').where('id', projects_id).update(updatedInfo, 'id');
+      // response.status(200).json({`Project with id ${projects_id} has been updated successfully`});
+      response.status(200).json({ id: id[0] });
+    } else {
+      response.status(404).json({
+        error: `Could not find project with an id of ${projects_id}`
+      })
+    }
+  } catch (error) {
+    response.status(500).json({ error });
+  }
+})
 
 module.exports = app;

--- a/app.test.js
+++ b/app.test.js
@@ -181,8 +181,16 @@ describe('Server', () => {
       const response = await request(app).patch(`/api/v1/palettes/${invalidId}`).send(correctionBody);
       expect(request.status).toBe(404);
       expect(request.body.error).toEqual(`Could not find project with an id of ${invalidId}`);
-    })
-  });
+    });
 
+    it('should return a 422 with an error message if info to update is invalid property', async () => {
+      const correctionBody = { color_one: 'New and improved palette name' };
+      const expectedPalette = await database('palettes').first();
+      const { id } = expectedPalette;
+      const response = await request(app).patch(`/api/v1/palettes/${id}`).send(correctionBody);
+      expect(response.status).toBe(422);
+      expect(response.body.error).toEqual('Expected body format is: { name: <String> }. You must send only the required "name" property.');
+    });
+  });
 
 });

--- a/app.test.js
+++ b/app.test.js
@@ -132,4 +132,31 @@ describe('Server', () => {
       expect(response.body.error).toEqual(`Could not find project with an id of ${invalidId}`);
     });
   });
+
+  describe('PATCH /api/v1/projects/:id', () => {
+    it('should return a 200 with a success message when project name is updated', async () => {
+      const correctionBody = { name: 'Updated Project Name' };
+      const expectedProject = await database('projects').first();
+      const { id } = expectedProject;
+      const response = await request(app).patch(`/api/v1/projects/${id}`).send(correctionBody);
+      console.log('response', response.body);
+      const updatedProject = await database('projects').where('id', id);
+      expect(response.status).toBe(200);
+      expect(response.body.id).toEqual(id);
+      expect(updatedProject[0].name).toEqual(correctionBody.name);
+    });
+
+    it('should return a 404 with a not found error message if item to update does not exist', async () => {
+      const correctionBody = { name: 'Updated Project Name' };
+      const invalidId = -6;
+      const response = await request(app).patch(`/api/v1/projects/${invalidId}`).send(correctionBody);
+      expect(response.status).toBe(404);
+      expect(response.body.error).toEqual(`Could not find project with an id of ${invalidId}`);
+    });
+
+    // it('should return a 422 with an error message if info to update is invalid', async () => {
+    //
+    // });
+  });
+
 });

--- a/app.test.js
+++ b/app.test.js
@@ -114,4 +114,15 @@ describe('Server', () => {
       expect(response.body.error).toEqual(`Could not find palette with an id of ${invalidId}`)
     });
   });
+
+  describe('DELETE /api/v1/projects/:id', () => {
+    it('should return a 200 with a success message if delete is successful', async () => {
+      const expectedProject = await database('projects').first();
+      const { id } = expectedProject;
+      const response = await request(app).delete(`/api/v1/projects/${id}`).send(`${id}`);
+      const doesExist = await database('projects').where('id', id);
+      expect(response.status).toBe(200);
+      expect(doesExist.length).toEqual(0);
+    });
+  });
 });

--- a/app.test.js
+++ b/app.test.js
@@ -179,8 +179,8 @@ describe('Server', () => {
       const correctionBody = { name: 'New and improved palette name' };
       const invalidId = -7;
       const response = await request(app).patch(`/api/v1/palettes/${invalidId}`).send(correctionBody);
-      expect(request.status).toBe(404);
-      expect(request.body.error).toEqual(`Could not find project with an id of ${invalidId}`);
+      expect(response.status).toBe(404);
+      expect(response.body.error).toEqual(`Could not find palette with an id of ${invalidId}`);
     });
 
     it('should return a 422 with an error message if info to update is invalid property', async () => {

--- a/app.test.js
+++ b/app.test.js
@@ -139,7 +139,6 @@ describe('Server', () => {
       const expectedProject = await database('projects').first();
       const { id } = expectedProject;
       const response = await request(app).patch(`/api/v1/projects/${id}`).send(correctionBody);
-      console.log('response', response.body);
       const updatedProject = await database('projects').where('id', id);
       expect(response.status).toBe(200);
       expect(response.body.id).toEqual(id);
@@ -154,9 +153,14 @@ describe('Server', () => {
       expect(response.body.error).toEqual(`Could not find project with an id of ${invalidId}`);
     });
 
-    // it('should return a 422 with an error message if info to update is invalid', async () => {
-    //
-    // });
+    it('should return a 422 with an error message if info to update is invalid property', async () => {
+      const correctionBody = { id: 'Updated Project Name' };
+      const expectedProject = await database('projects').first();
+      const { id } = expectedProject;
+      const response = await request(app).patch(`/api/v1/projects/${id}`).send(correctionBody);
+      expect(response.status).toBe(422);
+      expect(response.body.error).toEqual('Expected body format is: { name: <String> }. You must send only the required "name" property.');
+    });
   });
 
 });

--- a/app.test.js
+++ b/app.test.js
@@ -174,6 +174,15 @@ describe('Server', () => {
       expect(response.body.id).toEqual(id);
       expect(updatedPalette[0].name).toEqual(correctionBody.name);
     });
+
+    it('should return a 404 with a not found message if palette to update does not exist', async () => {
+      const correctionBody = { name: 'New and improved palette name' };
+      const invalidId = -7;
+      const response = await request(app).patch(`/api/v1/palettes/${invalidId}`).send(correctionBody);
+      expect(request.status).toBe(404);
+      expect(request.body.error).toEqual(`Could not find project with an id of ${invalidId}`);
+    })
   });
+
 
 });

--- a/app.test.js
+++ b/app.test.js
@@ -124,5 +124,12 @@ describe('Server', () => {
       expect(response.status).toBe(200);
       expect(doesExist.length).toEqual(0);
     });
+
+    it('should return a 404 with a not found error message if item to delete does not exist', async () => {
+      const invalidId = -5;
+      const response = await request(app).delete(`/api/v1/projects/${invalidId}`).send(`${invalidId}`);
+      expect(response.status).toBe(404);
+      expect(response.body.error).toEqual(`Could not find project with an id of ${invalidId}`);
+    });
   });
 });

--- a/app.test.js
+++ b/app.test.js
@@ -163,4 +163,17 @@ describe('Server', () => {
     });
   });
 
+  describe('PATCH /api/v1/palettes/:id', () => {
+    it('should return a 200 with a success message when palette name is updated', async () => {
+      const correctionBody = { name: 'New and improved palette name' };
+      const expectedPalette = await database('palettes').first();
+      const { id } = expectedPalette;
+      const response = await request(app).patch(`/api/v1/palettes/${id}`).send(correctionBody);
+      const updatedPalette = await database('palettes').where('id', id);
+      expect(response.status).toBe(200);
+      expect(response.body.id).toEqual(id);
+      expect(updatedPalette[0].name).toEqual(correctionBody.name);
+    });
+  });
+
 });


### PR DESCRIPTION
### What's this PR do?
- Add tests and endpoint for DELETE project
- Add tests and endpoint for PATCH update project name
- Add tests and endpoint for PATCH update palette name

### How should this be manually tested?
- Pull down branch and run `npm test`

### Any background context you want to provide?
- In order to DELETE project, the endpoint has to delete all palettes associated with that project
- For both PATCH endpoints, only the name property can be updated

### What are the relevant tickets?
Tickets #35, 36, 37, 38, 39, 40 (happy and sad paths for each of the 3 endpoints)

This PR completed all required endpoints and full testing for them.