### PR TITLE
Custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The server will run on `http://localhost:3000`.
 |----|----|----|----|----|
 | Get all projects |`/api/v1/projects`| GET | N/A | `{projects: [{}, {}, ...]}`   [See example](#all_projects) |
 | Get all palettes for a given project |`/api/v1/projects/:id/palettes`| GET | N/A | `{palettes: [{}, {}, ...]}` [See example](#all_palettes_by_project) |
+| Get all palettes (any project) |`/api/v1/palettes`| GET | N/A | `{palettes: [{}, {}, ...]}` [See example](#all_palettes_total) |
+| Get all palettes with queried color |`/api/v1/projects/:id/palettes?color=:hexcharacters`| GET | N/A | `{palettes: [{}, {}, ...]}` [See example](#all_palettes_by_query) |
 | Get specific project |`/api/v1/projects/:id`| GET | N/A | `{}`    [See example](#one_project) |
 | Get specific palette |`/api/v1/palettes/:id`| GET | N/A | `{}`  [See example](#one_palette) |
 | Post a project |`/api/v1/projects`| POST | `{ name: <String> }` | `{ id: <Number> }` [See example](#post_project) |
@@ -90,6 +92,61 @@ Sample Response:
   projects_id: 91,
   created_at: '2020-02-05T01:49:59.421Z',
   updated_at: '2020-02-05T01:49:59.421Z' }`
+
+### <a name="all_palettes_total"></a> GET all palettes (total, any project)
+Path: `/api/v1/palettes`
+Sample Response:
+`{ palettes:
+   [ { id: 6384,
+       name: 'Sample Palette one',
+       color_one: '#F7D951',
+       color_two: '#75B1FF',
+       color_three: '#985EEE',
+       color_four: '#5ED49B',
+       color_five: '#44638F',
+       projects_id: 3230,
+       created_at: 2020-02-08T00:59:46.352Z,
+       updated_at: 2020-02-08T00:59:46.352Z },
+     { id: 6385,
+       name: 'Sample Palette',
+       color_one: '#DC5551',
+       color_two: '#F2AD00',
+       color_three: '#6CA131',
+       color_four: '#4B5DC6',
+       color_five: '#1F0E95',
+       projects_id: 3231,
+       created_at: 2020-02-08T00:59:46.352Z,
+       updated_at: 2020-02-08T00:59:46.352Z } ] }`
+
+### <a name="all_palettes_by_query"></a> GET all palettes that match query (total, any project)
+Path: `/api/v1/palettes?color=:hexcharacters`
+Sample Query Format:
+Hex characters must be 6 digits. Digits/letters only - do not include "#".
+`/api/v1/palettes?color=FFFFFF`
+Sample Response:
+`{ palettes:
+  [ { id: 6384,
+    name: 'new palette one',
+    color_one: '#F7D951',
+    color_two: '#FFFFFF',
+    color_three: '#985EEE',
+    color_four: '#5ED49B',
+    color_five: '#44638F',
+    projects_id: 3230,
+    created_at: 2020-02-08T00:59:46.352Z,
+    updated_at: 2020-02-08T00:59:46.352Z
+  };
+  { id: 6385,
+    name: 'new palette two',
+    color_one: '#DC5551',
+    color_two: '#F2AD00',
+    color_three: '#6CA131',
+    color_four: '#4B5DC6',
+    color_five: '#FFFFFF',
+    projects_id: 3231,
+    created_at: 2020-02-08T00:59:46.352Z,
+    updated_at: 2020-02-08T00:59:46.352Z
+  } ] }`
 
 ### <a name="post_project"></a> POST a project
 Path: `/api/v1/projects`

--- a/app.js
+++ b/app.js
@@ -211,7 +211,7 @@ app.get('/api/v1/palettes', async (request, response) => {
 });
 
 const validateColorQuery = (color) => {
-  let regex = /[a-z\d][a-z\d][a-z\d][a-z\d][a-z\d][a-z\d]/ig;
+  let regex = /[0-9a-zA-Z]{6,}/;
   if (color.length === 6 && regex.test(color)) {
     return true;
   } else {

--- a/app.js
+++ b/app.js
@@ -28,7 +28,8 @@ app.get('/api/v1/projects/:id/palettes', async (request, response) => {
     const palettes = await database('palettes').where('projects_id', id);
     return palettes.length ?
     response.status(200).json({palettes}) :
-    response.status(404).json({Error: `No palettes could be found matching a project with an id of ${id}`});
+    response.status(404).json({Error:
+      `No palettes could be found matching a project with an id of ${id}`});
   } catch(error) {
     response.status(500).json({error});
   }
@@ -64,7 +65,8 @@ app.get('/api/v1/palettes/:id', async (request, response) => {
 app.post('/api/v1/projects', async (request, response) => {
   const project = request.body;
   if (!project.name) {
-    return response.status(422).json({error: 'Expected body format {name: <String>}. You\'re missing the required name property'});
+    return response.status(422).json({error:
+      'Expected body format {name: <String>}. You\'re missing the required name property'});
   }
   try {
     const id = await database('projects').insert(project, 'id');
@@ -81,9 +83,8 @@ app.post('/api/v1/projects/:id/palettes', async (request, response) => {
   for (let requiredParameter of ['name', 'color_one', 'color_two',
     'color_three', 'color_four', 'color_five', 'projects_id']) {
     if (!palette.hasOwnProperty(requiredParameter)) {
-      return response
-        .status(422)
-        .send({ error: `Expected body format is: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String> }. You\'re missing the required "${requiredParameter}" property.` })
+      return response.status(422).json({ error:
+        `Expected body format is: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String> }. You\'re missing the required "${requiredParameter}" property.` })
     }
   }
   try {
@@ -101,7 +102,8 @@ app.delete('/api/v1/projects/:id', async (request, response) => {
     if (foundProject.length) {
       await database('palettes').where('projects_id', projects_id).del();
       await database('projects').where('id', projects_id).del();
-      response.status(200).send(`Project with id ${projects_id} has been removed successfully`);
+      response.status(200).json(
+        `Project with id ${projects_id} has been removed successfully`);
     } else {
       response.status(404).json({
         error: `Could not find project with an id of ${projects_id}`
@@ -118,7 +120,8 @@ app.delete('/api/v1/palettes/:id', async (request, response) => {
     const found = await database('palettes').where('id', palettes_id);
     if (found.length) {
       await database('palettes').where('id', palettes_id).del();
-      response.status(200).send(`Palette with id ${palettes_id} has been removed successfully`);
+      response.status(200).json(
+        `Palette with id ${palettes_id} has been removed successfully`);
     } else {
       response.status(404).json({
         error: `Could not find palette with an id of ${palettes_id}`
@@ -136,13 +139,13 @@ app.patch('/api/v1/projects/:id', async (request, response) => {
   let requestKeys = Object.keys(updatedInfo);
 
   if (requestKeys.length !== 1 || requestKeys[0] !== 'name') {
-    return response
-      .status(422)
-      .send({ error: `Expected body format is: { name: <String> }. You must send only the required "name" property.` })
+    return response.status(422).json({ error:
+      `Expected body format is: { name: <String> }. You must send only the required "name" property.` })
   }
   try {
     if (foundProject.length) {
-      const id = await database('projects').where('id', projects_id).update(updatedInfo, 'id');
+      const id = await database('projects')
+        .where('id', projects_id).update(updatedInfo, 'id');
       // response.status(200).json({`Project with id ${projects_id} has been updated successfully`});
       response.status(200).json({ id: id[0] });
     } else {
@@ -164,11 +167,13 @@ app.patch('/api/v1/palettes/:id', async (request, response) => {
   if (requestKeys.length !== 1 || requestKeys[0] !== 'name') {
     return response
       .status(422)
-      .send({ error: `Expected body format is: { name: <String> }. You must send only the required "name" property.` })
+      .send({ error:
+        `Expected body format is: { name: <String> }. You must send only the required "name" property.` })
   }
   try {
     if (foundPalette.length) {
-      const id = await database('palettes').where('id', palettes_id).update(updatedInfo, 'id');
+      const id = await database('palettes')
+        .where('id', palettes_id).update(updatedInfo, 'id');
       response.status(200).json({ id: id[0] });
     } else {
       response.status(404).json({
@@ -179,5 +184,8 @@ app.patch('/api/v1/palettes/:id', async (request, response) => {
     response.status(500).json({ error });
   }
 });
+
+// custom endpoint
+
 
 module.exports = app;

--- a/app.test.js
+++ b/app.test.js
@@ -139,6 +139,7 @@ describe('Server', () => {
       const response = await request(app).delete(`/api/v1/projects/${id}`).send(`${id}`);
       const doesExist = await database('projects').where('id', id);
       expect(response.status).toBe(200);
+      expect(response.body).toEqual(`Project with id ${id} has been removed successfully`);
       expect(doesExist.length).toEqual(0);
     });
 
@@ -157,6 +158,7 @@ describe('Server', () => {
       const response = await request(app).delete(`/api/v1/palettes/${id}`).send(`${id}`);
       const doesExist = await database('palettes').where('id', id);
       expect(response.status).toBe(200);
+      expect(response.body).toEqual(`Palette with id ${id} has been removed successfully`)
       expect(doesExist.length).toEqual(0);
     });
 


### PR DESCRIPTION
### What's this PR do?
- Finishes the BE requirements
- Ensures all responses are in json format
- Ensures all testing requirements are met
    - Happy path status
    - Happy response content
    - Sad path(s) status
    - Sad path response content
- Adds custom endpoint with "color" query option
  - `/api/v1/palettes` without query will return all palettes regardless of project 
  - `/api/v1/palettes` with query (`/api/v1/palettes?color=ffffff`) will return all palettes that have that hex code as one of its colors
- Fully tests the custom endpoint

### How should this be manually tested?
- Pull down and run `npm test`

### What are the relevant tickets?
Tickets # 7, # 47, # 48